### PR TITLE
fix(frontend): migrate Trash to Trash2 + bump lucide-react to 1.41

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/xterm": "^6.0.0",
-        "lucide-react": "^1.38.0",
+        "lucide-react": "^1.41.0",
         "monaco-editor": "^0.56.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -2684,9 +2684,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.38.0.tgz",
-      "integrity": "sha512-xZCyBd/wiVUDactoCc+42TjL0aB7EBOXsuX+tjz+W/sGzw2KhHpL1NOH3FIaVUcpimvUBpIYfz34Ofj9S5JEzQ==",
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.41.0.tgz",
+      "integrity": "sha512-6lksP35l6KszDKUeRTi4LV7i6DEe0Yzl2ALJm9j4c5xEYN91GdW1xGsawGMOg2mgjF5GHBVX8pKX9kP+cWsP3Q==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/xterm": "^6.0.0",
-    "lucide-react": "^1.38.0",
+    "lucide-react": "^1.41.0",
     "monaco-editor": "^0.56.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/frontend/src/components/serverList/ServerGroupHeader.tsx
+++ b/frontend/src/components/serverList/ServerGroupHeader.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, ChevronUp, Folder, FolderOpen, Minus, Trash } from 'lucide-react';
+import { Check, ChevronDown, ChevronUp, Folder, FolderOpen, Minus, Trash2 } from 'lucide-react';
 import type React from 'react';
 import { useTranslation } from '../../i18n.ts';
 import { cn } from '../../utils/cn.ts';
@@ -72,7 +72,7 @@ export function ServerGroupHeader({
             className={cn('bg-transparent border-none cursor-pointer p-0.5 text-danger rounded-[var(--radius-sm)]', isTableView ? 'inline-flex' : 'flex')}
             aria-label={t('删除分组')}
           >
-            <Trash size={13} />
+            <Trash2 size={13} />
           </button>
         </Tiptop>
       )}


### PR DESCRIPTION
## Summary
- Bump lucide-react 1.38.0 -> 1.41.0
- Migrate last remaining `Trash` usage in `ServerGroupHeader.tsx` to `Trash2` (project already uses Trash2 everywhere else)

## Why
lucide-react 1.41.0 consolidated trash/trash-2 (`Trash2` is now an alias of `Trash`). Prefer the stable `Trash2` name used across the rest of the codebase so future icon renames do not break the build.

Closes #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **界面优化**
  - 更新分组删除按钮的图标样式，使其显示更加清晰、一致。
  - 除图标外，分组管理功能及操作方式保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->