### PR TITLE
fix(ai): 修复 AI 会话交互状态残留（追问卡残留/审批死卡/回首页误终止待批准任务）

### DIFF
--- a/frontend/src/components/ai/AIConversationTabPanel.tsx
+++ b/frontend/src/components/ai/AIConversationTabPanel.tsx
@@ -21,6 +21,7 @@ import { renderAIComposerSection, renderAISettingsOverlaySection } from './AICon
 import { AIWorkspaceTabProvider } from './aiWorkspaceTabContext.ts'
 import { subscribeAIWorkspaceTabGroups } from '../../utils/aiWorkspaceTabs.ts'
 import type { AIPanelProps } from './aiChatLogic.ts'
+import { hasStrandedAIInteractiveToolMessages } from './aiChatLogic.ts'
 import type { ConversationSummary } from './aiConversationSummary.ts'
 // ============================================================
 // AIConversationTabPanel：单个工作区标签页的对话面板（外壳见 ../../AIPanel.tsx）。
@@ -130,6 +131,9 @@ export function AIConversationTabPanel({ width, side, terminalId = 'global', ses
     : t('当前子代理任务已归档,仅可摘要压缩创建新的子阶段任务')
   const collaborationFollowupInteractionLocked = collaborationLocked && collaborationActive && panelState.collaborationMode === 'followup'
   const showAssistantCollaborationActiveImage = !isConversationLoading && collaborationActive && Boolean(activeConversation)
+  // 滞留的中间态工具卡片（如回首页时未批复的「待批准」）表示回合被打断而非结束，
+  // 此时即使末回合业务消息是 completion/followup 也应提供「继续任务」入口。
+  const hasStrandedInteractiveToolCard = useMemo(() => hasStrandedAIInteractiveToolMessages(panelState.messages), [panelState.messages])
   const toolResumeAvailable = Boolean(activeConversation)
     && !isArchivedAgentConversation
     && panelState.requestPhase === 'idle'
@@ -138,7 +142,9 @@ export function AIConversationTabPanel({ width, side, terminalId = 'global', ses
     && !panelState.isFlushingQueuedSubmission
     && !collaborationActive
     && !panelState.isCondensingContext
-    && (!panelState.lastTurnBusinessMessageKind || (panelState.lastTurnBusinessMessageKind !== 'completion' && panelState.lastTurnBusinessMessageKind !== 'followup'))
+    && (hasStrandedInteractiveToolCard
+      || !panelState.lastTurnBusinessMessageKind
+      || (panelState.lastTurnBusinessMessageKind !== 'completion' && panelState.lastTurnBusinessMessageKind !== 'followup'))
 
   const {
     conversationOrganizer, conversationFilter, setConversationFilter,

--- a/frontend/src/components/ai/aiChatLogic.ts
+++ b/frontend/src/components/ai/aiChatLogic.ts
@@ -827,33 +827,47 @@ export function upsertMessageBeforeAssistant(messages: unknown, requestId: unkno
 /** 请求结束后仍可能滞留在消息流里的工具中间态 */
 export const AI_TOOL_INTERMEDIATE_STATUSES = ['待批准', '执行中', '排队中, 等待终端空闲']
 
+/** 无实质执行结果的已终止工具卡片（空结果或仅剩"已终止"字样），一并视为可移除的滞留残留 */
+function isAIEmptyTerminatedToolMessage(message: AIMessage) {
+  if (normalizeAIMessageStatus(message?.status) !== '已终止') {
+    return false
+  }
+  const result = typeof message?.result === 'string' ? message.result.trim() : ''
+  const output = typeof message?.output === 'string' ? message.output.trim() : ''
+  return (!result || result === '已终止') && (!output || output === '已终止')
+}
+
 /**
- * 请求到达终态时，把滞留在中间态的工具卡片与待应答追问统一关闭，
- * 避免后端批次已丢弃而前端仍渲染可交互的死卡片。
+ * 请求到达终态时，把滞留在中间态的工具卡片与待应答追问统一清出会话：
+ * 从未获批执行的卡片没有记录价值，直接移除而非保留空壳；
+ * 待应答追问标记「已取消」并清空 requestId（渲染层按非待处理不再显示）。
  */
-export function closeAIStrandedInteractiveMessages(messages: unknown, toolStatus: string, closeFollowups = true): AIMessage[] {
+export function closeAIStrandedInteractiveMessages(messages: unknown, closeFollowups = true): AIMessage[] {
   const list = Array.isArray(messages) ? messages : []
   let changed = false
-  const nextMessages = list.map((message) => {
+  const nextMessages: AIMessage[] = []
+  for (const message of list) {
     const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
-    const status = normalizeAIMessageStatus(message?.status)
-    if ((kind === 'tool' || kind === 'command' || kind === 'mcp') && AI_TOOL_INTERMEDIATE_STATUSES.includes(status)) {
-      changed = true
-      return {
-        ...message,
-        status: toolStatus,
+    if (kind === 'tool' || kind === 'command' || kind === 'mcp') {
+      const status = normalizeAIMessageStatus(message?.status)
+      if (AI_TOOL_INTERMEDIATE_STATUSES.includes(status) || isAIEmptyTerminatedToolMessage(message)) {
+        changed = true
+        continue
       }
+      nextMessages.push(message)
+      continue
     }
-    if (closeFollowups && kind === 'followup' && status === AI_FOLLOWUP_PENDING_STATUS_KEY) {
+    if (closeFollowups && kind === 'followup' && normalizeAIMessageStatus(message?.status) === AI_FOLLOWUP_PENDING_STATUS_KEY) {
       changed = true
-      return {
+      nextMessages.push({
         ...message,
         status: AI_FOLLOWUP_CANCELLED_STATUS_KEY,
         requestId: '',
-      }
+      })
+      continue
     }
-    return message
-  })
+    nextMessages.push(message)
+  }
   return changed ? nextMessages : list
 }
 

--- a/frontend/src/components/ai/aiChatLogic.ts
+++ b/frontend/src/components/ai/aiChatLogic.ts
@@ -824,6 +824,39 @@ export function upsertMessageBeforeAssistant(messages: unknown, requestId: unkno
   return insertMessageBeforeAssistant(list, requestId, nextMessage)
 }
 
+/** 请求结束后仍可能滞留在消息流里的工具中间态 */
+export const AI_TOOL_INTERMEDIATE_STATUSES = ['待批准', '执行中', '排队中, 等待终端空闲']
+
+/**
+ * 请求到达终态时，把滞留在中间态的工具卡片与待应答追问统一关闭，
+ * 避免后端批次已丢弃而前端仍渲染可交互的死卡片。
+ */
+export function closeAIStrandedInteractiveMessages(messages: unknown, toolStatus: string, closeFollowups = true): AIMessage[] {
+  const list = Array.isArray(messages) ? messages : []
+  let changed = false
+  const nextMessages = list.map((message) => {
+    const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
+    const status = normalizeAIMessageStatus(message?.status)
+    if ((kind === 'tool' || kind === 'command' || kind === 'mcp') && AI_TOOL_INTERMEDIATE_STATUSES.includes(status)) {
+      changed = true
+      return {
+        ...message,
+        status: toolStatus,
+      }
+    }
+    if (closeFollowups && kind === 'followup' && status === AI_FOLLOWUP_PENDING_STATUS_KEY) {
+      changed = true
+      return {
+        ...message,
+        status: AI_FOLLOWUP_CANCELLED_STATUS_KEY,
+        requestId: '',
+      }
+    }
+    return message
+  })
+  return changed ? nextMessages : list
+}
+
 export function isAIBusinessTurnMessageKind(kind: unknown) {
   return Boolean(kind) && kind !== 'assistant' && kind !== 'reasoning' && kind !== 'user'
 }

--- a/frontend/src/components/ai/aiChatLogic.ts
+++ b/frontend/src/components/ai/aiChatLogic.ts
@@ -837,9 +837,18 @@ function isAIEmptyTerminatedToolMessage(message: AIMessage) {
   return (!result || result === '已终止') && (!output || output === '已终止')
 }
 
+/** 已拒绝的工具卡片从未真正执行（各拒绝路径只写占位文字），按「拒绝即移除」语义一并清理 */
+function isAIRejectedToolMessage(message: AIMessage) {
+  const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
+  if (kind !== 'tool' && kind !== 'command' && kind !== 'mcp') {
+    return false
+  }
+  return normalizeAIMessageStatus(message?.status) === '已拒绝'
+}
+
 /**
  * 请求到达终态时，把滞留在中间态的工具卡片与待应答追问统一清出会话：
- * 从未获批执行的卡片没有记录价值，直接移除而非保留空壳；
+ * 从未获批执行的卡片（中间态、空已终止壳、已拒绝）没有记录价值，直接移除而非保留空壳；
  * 待应答追问标记「已取消」并清空 requestId（渲染层按非待处理不再显示）。
  */
 export function closeAIStrandedInteractiveMessages(messages: unknown, closeFollowups = true): AIMessage[] {
@@ -850,7 +859,7 @@ export function closeAIStrandedInteractiveMessages(messages: unknown, closeFollo
     const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
     if (kind === 'tool' || kind === 'command' || kind === 'mcp') {
       const status = normalizeAIMessageStatus(message?.status)
-      if (AI_TOOL_INTERMEDIATE_STATUSES.includes(status) || isAIEmptyTerminatedToolMessage(message)) {
+      if (AI_TOOL_INTERMEDIATE_STATUSES.includes(status) || isAIEmptyTerminatedToolMessage(message) || isAIRejectedToolMessage(message)) {
         changed = true
         continue
       }

--- a/frontend/src/components/ai/aiChatLogic.ts
+++ b/frontend/src/components/ai/aiChatLogic.ts
@@ -861,35 +861,6 @@ export function isAIBusinessTurnMessageKind(kind: unknown) {
   return Boolean(kind) && kind !== 'assistant' && kind !== 'reasoning' && kind !== 'user'
 }
 
-/**
- * 从会话消息里推导仍悬而未决的工具审批。
- * 重新打开会话/返回面板时面板态会被重置为 idle，而后端批次仍在等待批复，
- * 这里依据最后一张「待批准」卡片还原审批条所需的 requestId（续轮 turnId 形如
- * `${requestID}-cont-<纳秒>`，剥掉后缀即原始请求 ID）。
- */
-export function deriveAIPendingToolApproval(messages: unknown): { requestId: string; toolApprovalMode: string } | null {
-  const list = Array.isArray(messages) ? messages : []
-  for (let index = list.length - 1; index >= 0; index -= 1) {
-    const message = list[index]
-    const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
-    if (kind !== 'tool' && kind !== 'command' && kind !== 'mcp') {
-      continue
-    }
-    if (normalizeAIMessageStatus(message?.status) !== '待批准') {
-      continue
-    }
-    const turnId = typeof message?.turnId === 'string' ? message.turnId.trim() : ''
-    if (!turnId) {
-      continue
-    }
-    return {
-      requestId: turnId.replace(/-cont-\d+$/, ''),
-      toolApprovalMode: 'inline',
-    }
-  }
-  return null
-}
-
 export function updateAILastAssistantTurnState(currentState: Pick<PanelState, 'lastAssistantTurnId'>, message: AIMessage, fallbackTurnId = ''): Partial<Pick<PanelState, 'lastAssistantTurnId' | 'lastTurnBusinessMessageKind'>> {
   const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
   if (!kind) {

--- a/frontend/src/components/ai/aiChatLogic.ts
+++ b/frontend/src/components/ai/aiChatLogic.ts
@@ -875,6 +875,21 @@ export function isAIBusinessTurnMessageKind(kind: unknown) {
   return Boolean(kind) && kind !== 'assistant' && kind !== 'reasoning' && kind !== 'user'
 }
 
+/**
+ * 会话里是否仍挂着中间态的工具/命令/MCP 卡片（例如回首页时未批复的「待批准」）。
+ * 这类卡片代表回合被打断而非自然结束，重新打开会话时应允许「继续任务」恢复。
+ */
+export function hasStrandedAIInteractiveToolMessages(messages: unknown): boolean {
+  const list = Array.isArray(messages) ? messages : []
+  return list.some((message) => {
+    const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
+    if (kind !== 'tool' && kind !== 'command' && kind !== 'mcp') {
+      return false
+    }
+    return AI_TOOL_INTERMEDIATE_STATUSES.includes(normalizeAIMessageStatus(message?.status))
+  })
+}
+
 export function updateAILastAssistantTurnState(currentState: Pick<PanelState, 'lastAssistantTurnId'>, message: AIMessage, fallbackTurnId = ''): Partial<Pick<PanelState, 'lastAssistantTurnId' | 'lastTurnBusinessMessageKind'>> {
   const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
   if (!kind) {

--- a/frontend/src/components/ai/aiChatLogic.ts
+++ b/frontend/src/components/ai/aiChatLogic.ts
@@ -295,6 +295,7 @@ export function normalizeAIMessageStatus(value: unknown) {
 
 export const AI_FOLLOWUP_PENDING_STATUS_KEY = '等待处理'
 export const AI_FOLLOWUP_COMPLETED_STATUS_KEY = '已完成'
+export const AI_FOLLOWUP_CANCELLED_STATUS_KEY = '已取消'
 
 export function truncateConversationTitle(text: unknown) {
   const normalized = String(text || '').trim().replace(/\s+/g, ' ')

--- a/frontend/src/components/ai/aiChatLogic.ts
+++ b/frontend/src/components/ai/aiChatLogic.ts
@@ -861,6 +861,35 @@ export function isAIBusinessTurnMessageKind(kind: unknown) {
   return Boolean(kind) && kind !== 'assistant' && kind !== 'reasoning' && kind !== 'user'
 }
 
+/**
+ * 从会话消息里推导仍悬而未决的工具审批。
+ * 重新打开会话/返回面板时面板态会被重置为 idle，而后端批次仍在等待批复，
+ * 这里依据最后一张「待批准」卡片还原审批条所需的 requestId（续轮 turnId 形如
+ * `${requestID}-cont-<纳秒>`，剥掉后缀即原始请求 ID）。
+ */
+export function deriveAIPendingToolApproval(messages: unknown): { requestId: string; toolApprovalMode: string } | null {
+  const list = Array.isArray(messages) ? messages : []
+  for (let index = list.length - 1; index >= 0; index -= 1) {
+    const message = list[index]
+    const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
+    if (kind !== 'tool' && kind !== 'command' && kind !== 'mcp') {
+      continue
+    }
+    if (normalizeAIMessageStatus(message?.status) !== '待批准') {
+      continue
+    }
+    const turnId = typeof message?.turnId === 'string' ? message.turnId.trim() : ''
+    if (!turnId) {
+      continue
+    }
+    return {
+      requestId: turnId.replace(/-cont-\d+$/, ''),
+      toolApprovalMode: 'inline',
+    }
+  }
+  return null
+}
+
 export function updateAILastAssistantTurnState(currentState: Pick<PanelState, 'lastAssistantTurnId'>, message: AIMessage, fallbackTurnId = ''): Partial<Pick<PanelState, 'lastAssistantTurnId' | 'lastTurnBusinessMessageKind'>> {
   const kind = typeof message?.kind === 'string' ? message.kind.trim() : ''
   if (!kind) {

--- a/frontend/src/components/ai/chat/AIChatFollowUpCard.tsx
+++ b/frontend/src/components/ai/chat/AIChatFollowUpCard.tsx
@@ -1,4 +1,5 @@
 import { MessageCircleQuestionMark } from 'lucide-react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from '../../../i18n.ts';
 import AIChatMarkdown from './AIChatMarkdown.tsx';
@@ -86,7 +87,7 @@ export default function AIChatFollowUpCard({ question, questions, suggestions, r
   const canGoPrevious = currentQuestionIndex > 0;
   const selectedIds = currentQuestion ? (answers[currentQuestion.id] || []) : [];
   const currentTextAnswer = currentQuestion ? (textAnswers[currentQuestion.id] || '') : '';
-  const canGoNext = currentQuestion?.type === 'free_text' ? true : selectedIds.length > 0;
+  const canGoNext = currentQuestion?.type === 'free_text' ? Boolean(currentTextAnswer.trim()) : selectedIds.length > 0;
   const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
 
   const submitResponse = useCallback(async (nextAnswers: Record<string, string[]>, nextTextAnswers: Record<string, string> = textAnswersRef.current || {}) => {
@@ -214,6 +215,15 @@ export default function AIChatFollowUpCard({ question, questions, suggestions, r
     }
   }, [canGoNext, currentQuestion, isFrozen, isLastQuestion, normalizedQuestions.length, startFreeze, submitResponse, submitting]);
 
+  const handleFreeTextKeyDown = useCallback((event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    // 输入法合成中的 Enter（确认候选词）不触发提交
+    if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) {
+      return;
+    }
+    event.preventDefault();
+    void handleGoNext();
+  }, [handleGoNext]);
+
   if (!currentQuestion) {
     return null;
   }
@@ -239,6 +249,7 @@ export default function AIChatFollowUpCard({ question, questions, suggestions, r
         transitionTick={transitionTick}
         transitionDirection={transitionDirection}
         handleFreeTextChange={handleFreeTextChange}
+        handleFreeTextKeyDown={handleFreeTextKeyDown}
         handleSingleSelect={handleSingleSelect}
         handleMultipleToggle={handleMultipleToggle}
         t={t}

--- a/frontend/src/components/ai/chat/AIChatToolSessionPane.tsx
+++ b/frontend/src/components/ai/chat/AIChatToolSessionPane.tsx
@@ -3,6 +3,7 @@ import AIChatCompletionCard from './AIChatCompletionCard.tsx'
 import AIChatFollowUpCard from './AIChatFollowUpCard.tsx'
 import AIChatMCPCard from './AIChatMCPCard.tsx'
 import AIChatToolCard from './AIChatToolCard.tsx'
+import { AI_FOLLOWUP_PENDING_STATUS_KEY, normalizeAIMessageStatus } from '../aiChatLogic.ts'
 import { cn } from '../../../utils/cn.ts'
 
 /** 会话工具条目（来自 .tsx 父级；kind 区分卡片类型，各卡片按需取用字段） */
@@ -57,12 +58,19 @@ function renderToolItem(item: AIChatToolSessionItem, options: AIChatToolSessionO
       return <AIChatCommandCard key={item.id} purpose={item.purpose} command={item.command} output={item.output} status={item.status} extra={item.extra} />
     case 'mcp':
       return <AIChatMCPCard key={item.id} serverName={item.serverName} toolName={item.toolName} args={item.args} response={item.response} extra={item.extra} isLast={isLastAssistantTurn} hasSubsequentAssistantMessage={hasSubsequentAssistantMessage} />
-    case 'followup':
+    case 'followup': {
+      // 已应答的追问（状态非待处理或 requestId 已清空）不再渲染交互框，答案已落入随后的用户消息
+      const followupStatus = normalizeAIMessageStatus(item.status)
+      const followupRequestId = typeof item.requestId === 'string' ? item.requestId.trim() : ''
+      if (!followupRequestId || (followupStatus && followupStatus !== AI_FOLLOWUP_PENDING_STATUS_KEY)) {
+        return null
+      }
       return (
         <div key={item.id} className={cn(followupInteractionLocked ? 'pointer-events-none opacity-60' : 'pointer-events-auto opacity-100')}>
           <AIChatFollowUpCard question={item.question} questions={item.questions || []} suggestions={item.suggestions || []} requestId={item.requestId} onSelectSuggestion={onSendUserMessage as (payload: unknown) => unknown} />
         </div>
       )
+    }
     default:
       return null
   }

--- a/frontend/src/components/ai/chat/AIChatToolSessionPane.tsx
+++ b/frontend/src/components/ai/chat/AIChatToolSessionPane.tsx
@@ -49,6 +49,10 @@ interface AIChatToolSessionPaneProps extends AIChatToolSessionOptions {
 
 function renderToolItem(item: AIChatToolSessionItem, options: AIChatToolSessionOptions) {
   const { isLastAssistantTurn = false, hasSubsequentAssistantMessage = false, onSendUserMessage, onPreviewRestore, onPreviewDiffFetch, onApplyRestore, onRestoreToHere, onReapplyRestore, followupInteractionLocked = false } = options
+  // 拒绝即移除语义：被拒绝的工具调用从未执行、不留会话痕迹（含历史遗留的已拒绝卡片）
+  if ((item.kind === 'tool' || item.kind === 'command' || item.kind === 'mcp') && normalizeAIMessageStatus(item.status) === '已拒绝') {
+    return null
+  }
   switch (item.kind) {
     case 'tool':
       return <AIChatToolCard key={item.id} restoreArtifactPath={typeof item?.extra?.restoreArtifactPath === 'string' ? item.extra.restoreArtifactPath : ''} copyContent={typeof item?.extra?.copyContent === 'string' ? item.extra.copyContent : ''} actionLabel={item.actionLabel} title={item.title} summary={item.summary} code={item.code} result={item.result} status={item.status} remainingFileEdits={item.remainingFileEdits} extra={item.extra} isLast={isLastAssistantTurn} hasSubsequentAssistantMessage={hasSubsequentAssistantMessage} onPreviewRestore={onPreviewRestore as (path: string, targetTerminalId?: string) => void} onPreviewDiffFetch={onPreviewDiffFetch as (path: string, targetTerminalId?: string) => Promise<unknown>} onApplyRestore={onApplyRestore as (path: string, targetTerminalId?: string) => boolean | Promise<boolean | null | undefined>} onRestoreToHere={onRestoreToHere as (path: string, targetTerminalId?: string) => boolean | Promise<boolean | null | undefined>} onReapplyRestore={onReapplyRestore as (path: string, targetTerminalId?: string) => boolean | Promise<boolean | null | undefined>} />

--- a/frontend/src/components/ai/chat/followUp/FollowUpOptionList.tsx
+++ b/frontend/src/components/ai/chat/followUp/FollowUpOptionList.tsx
@@ -1,4 +1,5 @@
 import { cn } from '../../../../utils/cn.ts';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 import {
   buildOptionButtonClass,
   type FollowUpQuestion,
@@ -19,6 +20,7 @@ export interface FollowUpOptionListProps {
   transitionTick: number;
   transitionDirection: 'next' | 'prev';
   handleFreeTextChange: (questionItem: FollowUpQuestion, value: string) => void;
+  handleFreeTextKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
   handleSingleSelect: (questionItem: FollowUpQuestion, optionId: string) => void;
   handleMultipleToggle: (questionItem: FollowUpQuestion, optionId: string) => void;
   t: (key: I18nKey, vars?: Record<string, unknown>) => string;
@@ -33,6 +35,7 @@ export default function FollowUpOptionList({
   transitionTick,
   transitionDirection,
   handleFreeTextChange,
+  handleFreeTextKeyDown,
   handleSingleSelect,
   handleMultipleToggle,
   t,
@@ -52,6 +55,7 @@ export default function FollowUpOptionList({
           name="ai-chat-followup-free-text"
           value={currentTextAnswer}
           onChange={(event) => handleFreeTextChange(currentQuestion, event.target.value)}
+          onKeyDown={handleFreeTextKeyDown}
           disabled={submitting || isFrozen}
           className="min-h-[140px] resize-y rounded-[var(--radius-md)] border border-line bg-overlay px-3.5 py-3 text-base leading-[1.6] text-primary outline-none"
         />

--- a/frontend/src/components/ai/useAIChatActions.ts
+++ b/frontend/src/components/ai/useAIChatActions.ts
@@ -66,18 +66,27 @@ export function useAIChatActions({ addToast, terminalId, workspaceTabId, activeC
     if (!panelState.activeRequestId) {
       return
     }
-    await approveAIChatTools(panelState.activeRequestId)
-  }, [panelState.activeRequestId])
+    try {
+      await approveAIChatTools(panelState.activeRequestId)
+    } catch (error) {
+      // 批准失败（如批次已被丢弃）必须可见，否则按钮看起来像点不动
+      await showAlert(error instanceof Error ? translate(error.message as I18nKey) : translate('操作失败'))
+    }
+  }, [panelState.activeRequestId, showAlert])
   const handleRejectTools = useCallback(async () => {
     if (!panelState.activeRequestId) {
       return
     }
-    if (normalizedGlobalAISettings.continueAfterToolRejection !== false) {
-      await rejectAIChatTools(panelState.activeRequestId)
-      return
+    try {
+      if (normalizedGlobalAISettings.continueAfterToolRejection !== false) {
+        await rejectAIChatTools(panelState.activeRequestId)
+        return
+      }
+      await rejectAIChatToolsForQueuedSubmission(panelState.activeRequestId)
+    } catch (error) {
+      await showAlert(error instanceof Error ? translate(error.message as I18nKey) : translate('操作失败'))
     }
-    await rejectAIChatToolsForQueuedSubmission(panelState.activeRequestId)
-  }, [normalizedGlobalAISettings.continueAfterToolRejection, panelState.activeRequestId])
+  }, [normalizedGlobalAISettings.continueAfterToolRejection, panelState.activeRequestId, showAlert])
   const handleContinueTool = useCallback(async () => {
     if (!panelState.activeRequestId) {
       return

--- a/frontend/src/components/ai/useAIChatStreamEvents.ts
+++ b/frontend/src/components/ai/useAIChatStreamEvents.ts
@@ -3,7 +3,7 @@ import { EventsOn } from '../../../wailsjs/runtime/runtime.js'
 import {
   buildAIUpstreamTokenUsage,
   normalizeAIUpstreamTokenValue,
-  AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_FOLLOWUP_CANCELLED_STATUS_KEY, AI_FOLLOWUP_PENDING_STATUS_KEY, buildAIQueuedSubmission, buildMetrics, buildReasoningDuration, insertMessageBeforeAssistant, normalizeAICollaborationDecision, normalizeAICollaborationMode, normalizeAIContextTokensValue, normalizeAIMessageStatus, normalizeAIRuntimePhase, parseAICollaborationStreamBuffer, resolveAIEventSound, trimLatestAssistantAPIHistoryMessage, updateAILastAssistantTurnState, upsertAPIHistoryMessage, upsertMessageBeforeAssistant,
+  AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_FOLLOWUP_PENDING_STATUS_KEY, buildAIQueuedSubmission, buildMetrics, buildReasoningDuration, closeAIStrandedInteractiveMessages, insertMessageBeforeAssistant, normalizeAICollaborationDecision, normalizeAICollaborationMode, normalizeAIContextTokensValue, normalizeAIMessageStatus, normalizeAIRuntimePhase, parseAICollaborationStreamBuffer, resolveAIEventSound, trimLatestAssistantAPIHistoryMessage, updateAILastAssistantTurnState, upsertAPIHistoryMessage, upsertMessageBeforeAssistant,
 } from './aiChatLogic.ts'
 import type { AIConversationSnapshot, AIMessage, PanelState } from './aiChatLogic.ts'
 import { disableAIChatCollaboration, startAIChatCollaboration } from './aiChatBridge.ts'
@@ -829,12 +829,14 @@ export function useAIChatStreamEvents({
       if (payload.kind === 'tool_execution_terminated') {
         let nextConversation = null
         setPanelState(matchedPanelKey, (current) => {
+          // 终止工具后批次内其余待批准/滞留卡片随请求一并关闭
+          const sweptMessages = closeAIStrandedInteractiveMessages(current.messages, '已终止')
           nextConversation = current.conversation
             ? {
                 ...current.conversation,
                 updatedAt: Date.now(),
                 status: 'idle',
-                messages: Array.isArray(current.messages) ? [...current.messages] : [],
+                messages: sweptMessages,
                 apiMessages: Array.isArray(current.apiMessages) ? [...current.apiMessages] : [],
               }
             : null
@@ -849,7 +851,7 @@ export function useAIChatStreamEvents({
             skipNextAutomaticRequest: false,
             resumeAfterCancelRequestId: '',
             conversation: nextConversation || current.conversation,
-            messages: nextConversation ? nextConversation.messages : current.messages,
+            messages: nextConversation ? nextConversation.messages : sweptMessages,
             apiMessages: nextConversation ? nextConversation.apiMessages : current.apiMessages,
             recoverableToolStopReason: 'terminated',
             collaborationLocked: false,
@@ -940,12 +942,14 @@ export function useAIChatStreamEvents({
         let nextConversation = null
         setPanelState(matchedPanelKey, (current) => {
           const shouldKeepCollaborationLock = current.collaborationLocked && !current.collaborationAwaitingManualFollowup && Boolean(current.queuedSubmission)
+          // 跳过自动续跑后滞留的工具卡片关闭；待应答追问仍需保留（手动追问流程未结束）
+          const sweptMessages = closeAIStrandedInteractiveMessages(current.messages, '已终止', false)
           nextConversation = current.conversation
             ? {
                 ...current.conversation,
                 updatedAt: Date.now(),
                 status: 'idle',
-                messages: Array.isArray(current.messages) ? [...current.messages] : [],
+                messages: sweptMessages,
                 apiMessages: Array.isArray(current.apiMessages) ? [...current.apiMessages] : [],
               }
             : null
@@ -1063,7 +1067,7 @@ export function useAIChatStreamEvents({
         const upstreamTokenUsage = buildAIUpstreamTokenUsage(payload, matchedPanel.upstreamInputTokens, matchedPanel.upstreamOutputTokens)
         const reasoningDuration = buildReasoningDuration(payload)
         const shouldClearSummarySubtaskCollaboration = matchedPanel.collaborationMode === 'summary_subtask'
-        const nextMessages = matchedPanel.messages.map((message) => {
+        const nextMessages = closeAIStrandedInteractiveMessages(matchedPanel.messages.map((message) => {
           if (message.id === `${assistantMessageId}-reasoning` && message.kind === 'reasoning') {
             return {
               ...message,
@@ -1088,7 +1092,7 @@ export function useAIChatStreamEvents({
               errorText: '',
             },
           }
-        })
+        }), '已终止')
         const nextConversation = {
           ...conversation,
           updatedAt: Date.now(),
@@ -1152,18 +1156,10 @@ export function useAIChatStreamEvents({
         const finalErrorText = payload.error || translate('请求失败')
         playAISound('progress')
 
-        const nextMessages = matchedPanel.messages
+        const nextMessages = closeAIStrandedInteractiveMessages(matchedPanel.messages
           .filter((message) => !(message.id === `${assistantMessageId}-reasoning` && message.kind === 'reasoning'))
           .map((message) => {
             if (message.id !== assistantMessageId || message.kind !== 'assistant') {
-              // 请求已失败：待应答的追问不再可回答，标记关闭避免残留可交互的死卡片
-              if (message?.kind === 'followup' && normalizeAIMessageStatus(message.status) === AI_FOLLOWUP_PENDING_STATUS_KEY && typeof message.requestId === 'string' && message.requestId.trim() === requestId) {
-                return {
-                  ...message,
-                  status: AI_FOLLOWUP_CANCELLED_STATUS_KEY,
-                  requestId: '',
-                }
-              }
               return message
             }
             return {
@@ -1177,7 +1173,7 @@ export function useAIChatStreamEvents({
                 errorText: finalErrorText,
               },
             }
-          })
+          }), '已终止')
         const nextConversation = {
           ...conversation,
           updatedAt: Date.now(),
@@ -1216,7 +1212,7 @@ export function useAIChatStreamEvents({
 
       if (payload.kind === 'cancelled') {
         const assistantMessageId = matchedPanel.activeAssistantMessageId || requestId
-        const nextMessages = matchedPanel.messages.filter((message) => {
+        const nextMessages = closeAIStrandedInteractiveMessages(matchedPanel.messages.filter((message) => {
           if (message.id === `${assistantMessageId}-reasoning` && message.kind === 'reasoning') {
             return false
           }
@@ -1224,17 +1220,7 @@ export function useAIChatStreamEvents({
             return false
           }
           return true
-        }).map((message) => {
-          // 请求已取消：后端会丢弃待处理追问批次，这里同步关闭消息，避免残留可交互的死卡片
-          if (message?.kind === 'followup' && normalizeAIMessageStatus(message.status) === AI_FOLLOWUP_PENDING_STATUS_KEY && typeof message.requestId === 'string' && message.requestId.trim() === requestId) {
-            return {
-              ...message,
-              status: AI_FOLLOWUP_CANCELLED_STATUS_KEY,
-              requestId: '',
-            }
-          }
-          return message
-        })
+        }), '已终止')
         const nextConversation = {
           ...conversation,
           updatedAt: Date.now(),

--- a/frontend/src/components/ai/useAIChatStreamEvents.ts
+++ b/frontend/src/components/ai/useAIChatStreamEvents.ts
@@ -347,6 +347,8 @@ export function useAIChatStreamEvents({
         setComposerInputValue('')
         setPanelState(matchedPanelKey, (current) => ({
           ...current,
+          // 协同任务收尾后关闭滞留的待批准/执行中工具卡片；fallback 追问随后才到场，不在此关闭
+          messages: closeAIStrandedInteractiveMessages(current.messages, '已终止', false),
           collaborationLocked: isFallbackFollowup ? false : current.collaborationLocked,
           collaborationActive: false,
           collaborationMode: '',
@@ -963,6 +965,7 @@ export function useAIChatStreamEvents({
             runtimePhase: 'ready',
             skipNextAutomaticRequest: false,
             conversation: nextConversation || current.conversation,
+            messages: nextConversation ? nextConversation.messages : current.messages,
             recoverableToolStopReason: '',
             collaborationLocked: shouldKeepCollaborationLock,
             collaborationActive: false,

--- a/frontend/src/components/ai/useAIChatStreamEvents.ts
+++ b/frontend/src/components/ai/useAIChatStreamEvents.ts
@@ -3,7 +3,7 @@ import { EventsOn } from '../../../wailsjs/runtime/runtime.js'
 import {
   buildAIUpstreamTokenUsage,
   normalizeAIUpstreamTokenValue,
-  AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_FOLLOWUP_PENDING_STATUS_KEY, buildAIQueuedSubmission, buildMetrics, buildReasoningDuration, closeAIStrandedInteractiveMessages, insertMessageBeforeAssistant, normalizeAICollaborationDecision, normalizeAICollaborationMode, normalizeAIContextTokensValue, normalizeAIMessageStatus, normalizeAIRuntimePhase, parseAICollaborationStreamBuffer, resolveAIEventSound, trimLatestAssistantAPIHistoryMessage, updateAILastAssistantTurnState, upsertAPIHistoryMessage, upsertMessageBeforeAssistant,
+  AI_FOLLOWUP_PENDING_STATUS_KEY, AI_TOOL_INTERMEDIATE_STATUSES, buildAIQueuedSubmission, buildMetrics, buildReasoningDuration, closeAIStrandedInteractiveMessages, insertMessageBeforeAssistant, normalizeAICollaborationDecision, normalizeAICollaborationMode, normalizeAIContextTokensValue, normalizeAIMessageStatus, normalizeAIRuntimePhase, parseAICollaborationStreamBuffer, resolveAIEventSound, trimLatestAssistantAPIHistoryMessage, updateAILastAssistantTurnState, upsertAPIHistoryMessage, upsertMessageBeforeAssistant,
 } from './aiChatLogic.ts'
 import type { AIConversationSnapshot, AIMessage, PanelState } from './aiChatLogic.ts'
 import { disableAIChatCollaboration, startAIChatCollaboration } from './aiChatBridge.ts'
@@ -584,8 +584,16 @@ export function useAIChatStreamEvents({
               requestId: '',
             }
           }
+          // 拒绝路径补发的「已拒绝」卡片不再回插会话：拒绝即移除
+          const upsertKind = typeof normalizedMessage?.kind === 'string' ? normalizedMessage.kind.trim() : ''
+          if ((upsertKind === 'tool' || upsertKind === 'command' || upsertKind === 'mcp') && normalizeAIMessageStatus(normalizedMessage?.status) === '已拒绝') {
+            return null
+          }
           return normalizedMessage
         })()
+        if (!nextMessage) {
+          return
+        }
         setPanelState(matchedPanelKey, (current) => {
           const fallbackTurnId = current.activeAssistantMessageId || requestId
           return {
@@ -875,26 +883,26 @@ export function useAIChatStreamEvents({
         const shouldResumeAfterCancel = matchedPanel.resumeAfterCancelRequestId === requestId
         setPanelState(matchedPanelKey, (current) => {
           const assistantMessageId = current.activeAssistantMessageId || requestId
-          const nextMessages = current.messages.map((message) => {
-            if (message.id === assistantMessageId && message.kind === 'assistant') {
-              return {
-                ...message,
-                metrics: Array.isArray(message.metrics) ? message.metrics : [],
-                streaming: false,
-                extra: {
-                  ...(message.extra || {}),
-                  requestStatusLive: false,
-                },
+          // 拒绝即移除：未获批执行的卡片不留"已拒绝"空壳，拒绝结果经 API 历史告知模型即可
+          const nextMessages = current.messages
+            .filter((message) => !(
+              (message.kind === 'tool' || message.kind === 'command' || message.kind === 'mcp')
+              && AI_TOOL_INTERMEDIATE_STATUSES.includes(normalizeAIMessageStatus(message.status))
+            ))
+            .map((message) => {
+              if (message.id === assistantMessageId && message.kind === 'assistant') {
+                return {
+                  ...message,
+                  metrics: Array.isArray(message.metrics) ? message.metrics : [],
+                  streaming: false,
+                  extra: {
+                    ...(message.extra || {}),
+                    requestStatusLive: false,
+                  },
+                }
               }
-            }
-            if ((message.kind === 'tool' || message.kind === 'command') && AI_CONVERSATION_DIFF_SUCCESS_STATUSES.size >= 0 && ['待批准', '执行中', AI_FOLLOWUP_PENDING_STATUS_KEY, '排队中, 等待终端空闲'].includes(normalizeAIMessageStatus(message.status))) {
-              return {
-                ...message,
-                status: '已拒绝',
-              }
-            }
-            return message
-          })
+              return message
+            })
           nextConversation = current.conversation
             ? {
                 ...current.conversation,

--- a/frontend/src/components/ai/useAIChatStreamEvents.ts
+++ b/frontend/src/components/ai/useAIChatStreamEvents.ts
@@ -3,7 +3,7 @@ import { EventsOn } from '../../../wailsjs/runtime/runtime.js'
 import {
   buildAIUpstreamTokenUsage,
   normalizeAIUpstreamTokenValue,
-  AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_FOLLOWUP_PENDING_STATUS_KEY, buildAIQueuedSubmission, buildMetrics, buildReasoningDuration, insertMessageBeforeAssistant, normalizeAICollaborationDecision, normalizeAICollaborationMode, normalizeAIContextTokensValue, normalizeAIMessageStatus, normalizeAIRuntimePhase, parseAICollaborationStreamBuffer, resolveAIEventSound, trimLatestAssistantAPIHistoryMessage, updateAILastAssistantTurnState, upsertAPIHistoryMessage, upsertMessageBeforeAssistant,
+  AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_FOLLOWUP_CANCELLED_STATUS_KEY, AI_FOLLOWUP_PENDING_STATUS_KEY, buildAIQueuedSubmission, buildMetrics, buildReasoningDuration, insertMessageBeforeAssistant, normalizeAICollaborationDecision, normalizeAICollaborationMode, normalizeAIContextTokensValue, normalizeAIMessageStatus, normalizeAIRuntimePhase, parseAICollaborationStreamBuffer, resolveAIEventSound, trimLatestAssistantAPIHistoryMessage, updateAILastAssistantTurnState, upsertAPIHistoryMessage, upsertMessageBeforeAssistant,
 } from './aiChatLogic.ts'
 import type { AIConversationSnapshot, AIMessage, PanelState } from './aiChatLogic.ts'
 import { disableAIChatCollaboration, startAIChatCollaboration } from './aiChatBridge.ts'
@@ -1156,6 +1156,14 @@ export function useAIChatStreamEvents({
           .filter((message) => !(message.id === `${assistantMessageId}-reasoning` && message.kind === 'reasoning'))
           .map((message) => {
             if (message.id !== assistantMessageId || message.kind !== 'assistant') {
+              // 请求已失败：待应答的追问不再可回答，标记关闭避免残留可交互的死卡片
+              if (message?.kind === 'followup' && normalizeAIMessageStatus(message.status) === AI_FOLLOWUP_PENDING_STATUS_KEY && typeof message.requestId === 'string' && message.requestId.trim() === requestId) {
+                return {
+                  ...message,
+                  status: AI_FOLLOWUP_CANCELLED_STATUS_KEY,
+                  requestId: '',
+                }
+              }
               return message
             }
             return {
@@ -1198,6 +1206,8 @@ export function useAIChatStreamEvents({
           collaborationStreamBuffer: '',
           collaborationAwaitingManualFollowup: false,
           collaborationFollowupRequestId: '',
+          collaborationPendingMode: '',
+          collaborationPendingRequestId: '',
         })
 
         void saveConversationSnapshot(nextConversation, matchedPanelKey)
@@ -1214,6 +1224,16 @@ export function useAIChatStreamEvents({
             return false
           }
           return true
+        }).map((message) => {
+          // 请求已取消：后端会丢弃待处理追问批次，这里同步关闭消息，避免残留可交互的死卡片
+          if (message?.kind === 'followup' && normalizeAIMessageStatus(message.status) === AI_FOLLOWUP_PENDING_STATUS_KEY && typeof message.requestId === 'string' && message.requestId.trim() === requestId) {
+            return {
+              ...message,
+              status: AI_FOLLOWUP_CANCELLED_STATUS_KEY,
+              requestId: '',
+            }
+          }
+          return message
         })
         const nextConversation = {
           ...conversation,
@@ -1243,6 +1263,8 @@ export function useAIChatStreamEvents({
           collaborationStreamBuffer: '',
           collaborationAwaitingManualFollowup: false,
           collaborationFollowupRequestId: '',
+          collaborationPendingMode: '',
+          collaborationPendingRequestId: '',
         })
 
         void saveConversationSnapshot(nextConversation, matchedPanelKey)

--- a/frontend/src/components/ai/useAIChatStreamEvents.ts
+++ b/frontend/src/components/ai/useAIChatStreamEvents.ts
@@ -348,7 +348,7 @@ export function useAIChatStreamEvents({
         setPanelState(matchedPanelKey, (current) => ({
           ...current,
           // 协同任务收尾后关闭滞留的待批准/执行中工具卡片；fallback 追问随后才到场，不在此关闭
-          messages: closeAIStrandedInteractiveMessages(current.messages, '已终止', false),
+          messages: closeAIStrandedInteractiveMessages(current.messages, false),
           collaborationLocked: isFallbackFollowup ? false : current.collaborationLocked,
           collaborationActive: false,
           collaborationMode: '',
@@ -832,7 +832,7 @@ export function useAIChatStreamEvents({
         let nextConversation = null
         setPanelState(matchedPanelKey, (current) => {
           // 终止工具后批次内其余待批准/滞留卡片随请求一并关闭
-          const sweptMessages = closeAIStrandedInteractiveMessages(current.messages, '已终止')
+          const sweptMessages = closeAIStrandedInteractiveMessages(current.messages)
           nextConversation = current.conversation
             ? {
                 ...current.conversation,
@@ -945,7 +945,7 @@ export function useAIChatStreamEvents({
         setPanelState(matchedPanelKey, (current) => {
           const shouldKeepCollaborationLock = current.collaborationLocked && !current.collaborationAwaitingManualFollowup && Boolean(current.queuedSubmission)
           // 跳过自动续跑后滞留的工具卡片关闭；待应答追问仍需保留（手动追问流程未结束）
-          const sweptMessages = closeAIStrandedInteractiveMessages(current.messages, '已终止', false)
+          const sweptMessages = closeAIStrandedInteractiveMessages(current.messages, false)
           nextConversation = current.conversation
             ? {
                 ...current.conversation,
@@ -1095,7 +1095,7 @@ export function useAIChatStreamEvents({
               errorText: '',
             },
           }
-        }), '已终止')
+        }))
         const nextConversation = {
           ...conversation,
           updatedAt: Date.now(),
@@ -1176,7 +1176,7 @@ export function useAIChatStreamEvents({
                 errorText: finalErrorText,
               },
             }
-          }), '已终止')
+          }))
         const nextConversation = {
           ...conversation,
           updatedAt: Date.now(),
@@ -1223,7 +1223,7 @@ export function useAIChatStreamEvents({
             return false
           }
           return true
-        }), '已终止')
+        }))
         const nextConversation = {
           ...conversation,
           updatedAt: Date.now(),

--- a/frontend/src/components/ai/useAIConversationHome.ts
+++ b/frontend/src/components/ai/useAIConversationHome.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type * as React from 'react'
 import { getAIProviderState, type AIProviderState } from './aiProviderBridge.ts'
 import type { AIProviderLike } from './AIProviderSelector.tsx'
-import { AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_CONVERSATION_DIFF_TOOL_NAMES, buildAIRequestModelMeta, computeAILastAssistantTurnState, createEmptyPanelState, deriveAIPendingToolApproval, extractAIConversationDiffPrimaryPath, normalizeAIMessageStatus } from './aiChatLogic.ts'
+import { AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_CONVERSATION_DIFF_TOOL_NAMES, buildAIRequestModelMeta, computeAILastAssistantTurnState, createEmptyPanelState, extractAIConversationDiffPrimaryPath, normalizeAIMessageStatus } from './aiChatLogic.ts'
 import type { AIConversationSnapshot, AIMessage, AIPanelProps, ComposerEditState, PanelState, TokenLedger } from './aiChatLogic.ts'
 import { cancelAIChat } from './aiChatBridge.ts'
 import { deleteAIConversation, deleteTemporaryAIConversation, getAIConversation, getTemporaryAIConversation, listAIConversations, listTemporaryAIConversations as listTemporaryAIConversationsFromDisk, normalizeAIConversationTaskSettings, openAIConversationFolder, saveAIConversation, saveTemporaryAIConversation, subscribeAIConversationChanges, type AIConversationMessageSearchResult } from './aiConversationBridge.ts'
@@ -435,18 +435,16 @@ export function useAIConversationHome({ t, addToast, terminalId, sessionId, work
         providers: latestProviders,
       })
       setConversationList((prev) => upsertConversationSummary(prev, nextSnapshot))
-      // 返回面板/重开会话时，若仍有「待批准」工具卡片则恢复审批条（后端批次仍在等待批复）
-      const pendingToolApproval = deriveAIPendingToolApproval(nextSnapshot.messages)
       setPanelState(panelInstanceKey, {
         activeConversationId: nextSnapshot.id,
         conversation: nextSnapshot,
         messages: nextSnapshot.messages,
         apiMessages: nextSnapshot.apiMessages,
-        activeRequestId: pendingToolApproval?.requestId || '',
+        activeRequestId: '',
         activeAssistantMessageId: '',
         activeToolExecution: null,
-        toolApprovalMode: pendingToolApproval?.toolApprovalMode || '',
-        requestPhase: pendingToolApproval ? 'awaiting_tool_approval' : 'idle',
+        toolApprovalMode: '',
+        requestPhase: 'idle',
         runtimePhase: 'ready',
         queuedSubmission: null,
         isFlushingQueuedSubmission: false,

--- a/frontend/src/components/ai/useAIConversationHome.ts
+++ b/frontend/src/components/ai/useAIConversationHome.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type * as React from 'react'
 import { getAIProviderState, type AIProviderState } from './aiProviderBridge.ts'
 import type { AIProviderLike } from './AIProviderSelector.tsx'
-import { AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_CONVERSATION_DIFF_TOOL_NAMES, buildAIRequestModelMeta, computeAILastAssistantTurnState, createEmptyPanelState, extractAIConversationDiffPrimaryPath, normalizeAIMessageStatus } from './aiChatLogic.ts'
+import { AI_CONVERSATION_DIFF_SUCCESS_STATUSES, AI_CONVERSATION_DIFF_TOOL_NAMES, buildAIRequestModelMeta, computeAILastAssistantTurnState, createEmptyPanelState, deriveAIPendingToolApproval, extractAIConversationDiffPrimaryPath, normalizeAIMessageStatus } from './aiChatLogic.ts'
 import type { AIConversationSnapshot, AIMessage, AIPanelProps, ComposerEditState, PanelState, TokenLedger } from './aiChatLogic.ts'
 import { cancelAIChat } from './aiChatBridge.ts'
 import { deleteAIConversation, deleteTemporaryAIConversation, getAIConversation, getTemporaryAIConversation, listAIConversations, listTemporaryAIConversations as listTemporaryAIConversationsFromDisk, normalizeAIConversationTaskSettings, openAIConversationFolder, saveAIConversation, saveTemporaryAIConversation, subscribeAIConversationChanges, type AIConversationMessageSearchResult } from './aiConversationBridge.ts'
@@ -435,16 +435,18 @@ export function useAIConversationHome({ t, addToast, terminalId, sessionId, work
         providers: latestProviders,
       })
       setConversationList((prev) => upsertConversationSummary(prev, nextSnapshot))
+      // 返回面板/重开会话时，若仍有「待批准」工具卡片则恢复审批条（后端批次仍在等待批复）
+      const pendingToolApproval = deriveAIPendingToolApproval(nextSnapshot.messages)
       setPanelState(panelInstanceKey, {
         activeConversationId: nextSnapshot.id,
         conversation: nextSnapshot,
         messages: nextSnapshot.messages,
         apiMessages: nextSnapshot.apiMessages,
-        activeRequestId: '',
+        activeRequestId: pendingToolApproval?.requestId || '',
         activeAssistantMessageId: '',
         activeToolExecution: null,
-        toolApprovalMode: '',
-        requestPhase: 'idle',
+        toolApprovalMode: pendingToolApproval?.toolApprovalMode || '',
+        requestPhase: pendingToolApproval ? 'awaiting_tool_approval' : 'idle',
         runtimePhase: 'ready',
         queuedSubmission: null,
         isFlushingQueuedSubmission: false,

--- a/frontend/src/components/ai/useAIPanelCoreState.ts
+++ b/frontend/src/components/ai/useAIPanelCoreState.ts
@@ -33,6 +33,9 @@ export function useAIPanelCoreState({ terminalId, sessionId, workspaceTabId, ini
   const panelMountedRef = useRef(true)
   const tokenLedgerRef = useRef<Map<string, TokenLedger>>(new Map())
   const sendPerfMetricsRef = useRef<Map<string, PerfRecord>>(new Map())
+  // 同一会话的快照保存串行链：流式 upsert 与终态清理的保存并发时，若旧快照后落盘
+  // 会把清理结果覆盖回去（滞留卡片复活），必须保证逻辑上最后一次保存最后写入。
+  const conversationSnapshotSaveQueuesRef = useRef<Map<string, Promise<AIConversationSnapshot | undefined>>>(new Map())
   const panelInstanceKey = `${sessionId || 'session'}::${terminalId || 'terminal'}`
   const clearRestorePreview = useCallback(() => {
     if (typeof window === 'undefined') {
@@ -322,34 +325,46 @@ export function useAIPanelCoreState({ terminalId, sessionId, workspaceTabId, ini
     }
     const shouldHydrate = options?.hydrate === true
     const isTransientConversation = snapshot?.transient === true
-    const saved = isTransientConversation
-      ? await saveTemporaryAIConversation(snapshot)
-      : await saveAIConversation(snapshot)
-    if (isTransientConversation) upsertTemporaryAIConversation(saved)
-    setConversationList((prev) => upsertConversationSummary(prev, saved))
-    setPanelState(targetPanelKey, (current) => {
-      if (current.activeConversationId !== saved.id) {
-        return current
-      }
-      if (!shouldHydrate) {
+    const performSave = async () => {
+      const saved = isTransientConversation
+        ? await saveTemporaryAIConversation(snapshot)
+        : await saveAIConversation(snapshot)
+      if (isTransientConversation) upsertTemporaryAIConversation(saved)
+      setConversationList((prev) => upsertConversationSummary(prev, saved))
+      setPanelState(targetPanelKey, (current) => {
+        if (current.activeConversationId !== saved.id) {
+          return current
+        }
+        if (!shouldHydrate) {
+          return {
+            ...current,
+            conversation: {
+              ...saved,
+              messages: current.messages,
+              apiMessages: current.apiMessages,
+            },
+          }
+        }
         return {
           ...current,
-          conversation: {
-            ...saved,
-            messages: current.messages,
-            apiMessages: current.apiMessages,
-          },
+          conversation: saved,
+          messages: saved.messages || [],
+          apiMessages: saved.apiMessages || [],
         }
-      }
-      return {
-        ...current,
-        conversation: saved,
-        messages: saved.messages || [],
-        apiMessages: saved.apiMessages || [],
+      })
+      void refreshAIConversationContextTokens(saved, targetPanelKey)
+      return saved
+    }
+    const saveQueues = conversationSnapshotSaveQueuesRef.current
+    const previousSave = saveQueues.get(snapshot.id) || Promise.resolve(undefined)
+    const chainedSave = previousSave.catch(() => undefined).then(performSave)
+    saveQueues.set(snapshot.id, chainedSave)
+    void chainedSave.finally(() => {
+      if (saveQueues.get(snapshot.id) === chainedSave) {
+        saveQueues.delete(snapshot.id)
       }
     })
-    void refreshAIConversationContextTokens(saved, targetPanelKey)
-    return saved
+    return chainedSave
   }, [panelInstanceKey, refreshAIConversationContextTokens, setPanelState])
   useEffect(() => {
     if (terminalPanelsRef.current[panelInstanceKey]) {

--- a/frontend/src/components/ai/useAIPanelCoreState.ts
+++ b/frontend/src/components/ai/useAIPanelCoreState.ts
@@ -385,6 +385,34 @@ export function useAIPanelCoreState({ terminalId, sessionId, workspaceTabId, ini
           apiMessages: Array.isArray(panel.apiMessages) ? panel.apiMessages : (Array.isArray(conversation.apiMessages) ? conversation.apiMessages : []),
         }).catch(() => {})
       }
+      // 卸载前先解除请求绑定并复位请求相位再取消：cancelled 事件按 activeRequestId 匹配面板，
+      // 提前解绑可避免终态清理把可恢复的「待批准」卡片覆盖为已终止；相位复位则避免重新挂载时
+      // 渲染出指向已丢弃批次的死审批条（请求已取消，应走「继续任务」重新发起）。
+      // 会话数据保留在面板上：临时会话未经持久化，清空会在重进时丢失。
+      terminalPanelsRef.current = {
+        ...terminalPanelsRef.current,
+        [panelInstanceKey]: {
+          ...panel,
+          activeRequestId: '',
+          activeAssistantMessageId: '',
+          activeToolExecution: null,
+          toolApprovalMode: '',
+          requestPhase: 'idle',
+          runtimePhase: 'ready',
+          queuedSubmission: null,
+          isFlushingQueuedSubmission: false,
+          skipNextAutomaticRequest: false,
+          resumeAfterCancelRequestId: '',
+          recoverableToolStopReason: '',
+          isCondensingContext: false,
+          collaborationLocked: false,
+          collaborationActive: false,
+          collaborationMode: '',
+          collaborationStreamBuffer: '',
+          collaborationAwaitingManualFollowup: false,
+          collaborationFollowupRequestId: '',
+        },
+      }
       void cancelAIChat(requestId)
     }
   }, [panelInstanceKey])


### PR DESCRIPTION
本 PR 系统性修复 AI 会话的「交互状态残留」问题：应随请求结束消失的交互组件（追问卡、工具审批卡）滞留在会话里成为死卡片，回首页后待批准任务被误终止无法恢复，以及拒绝工具调用后残留「已拒绝」空壳卡片。

### 修复内容

**1. 追问卡应答后残留（9f7cbf32）**
- 应答提交后卡片不再滞留：渲染层校验 status，非「等待处理」或 requestId 为空时不渲染
- 空自由文本禁止提交（原先空答案会被解析兜底当成原始 JSON 发给 AI，导致重复追问死循环）
- 自由文本支持 Enter 提交（带 isComposing 防输入法误触）

**2. 请求终态滞留工具卡清理（e5e8698c / 18dd7fa7 / bab6b1a8 / 4f55474f）**
- 请求到达终态（取消/失败/工具终止/拒绝/attempt_completion 完成/协同完成）时统一清理中间态（待批准/执行中/排队中）工具卡
- 待应答追问标记「已取消」并清空 requestId
- bab6b1a8 修复完成路径（automatic_request_skipped）清理漏传 messages 字段导致不生效的问题
- 4f55474f 终态清理由「标记已终止」改为直接移除（含空已终止壳），消除完成任务底部卡空壳

**3. 回首页待批准任务被误终止（39d8a3b7）**
- 面板卸载清理调用 CancelAIChat 丢弃待批准批次，若未先解除面板绑定，cancelled 事件触发的终态清理会把可恢复的「待批准」卡片覆盖为「已终止」并保存——重进会话任务已死
- 修复：卸载清理先解除请求绑定并复位请求相位再取消；重新挂载不再渲染指向已丢弃批次的审批条
- 滞留中间态卡片时豁免「继续任务」入口的 completion/followup 隐藏规则：重进会话先显示「继续任务」，点击走官方 resumeAIChatFromConversation 流程重新发起，批准/拒绝随新请求正常出现

**4. 终态清理被并发旧快照覆盖（a98276f1）**
- attempt_completion 结束时后端连发 upsert_message 与 automatic_request_skipped，两个事件各自异步保存会话快照、写盘无序，旧快照可能后落盘把清理结果覆盖回去（滞留卡片复活）
- 修复：saveConversationSnapshot 按会话 id 串行化保存链，保证逻辑上最后一次保存（终态清理）最后落盘

**5. 拒绝工具调用即移除卡片（d82d27c4）**
- 拒绝后不再保留「已拒绝」空壳卡片：tool_rejected 终态直接移除中间态卡片
- upsert_message 拦截各拒绝路径（手动拒绝/自动拒绝/强制介入）补发的已拒绝卡片，不再回插
- 渲染层对已拒绝工具卡一律不渲染（历史遗留卡片同样隐藏）；终态清理同步扫除
- 拒绝结果仍经 API 历史告知模型，不影响模型上下文

**6. 批准/拒绝失败静默无反应（12c69bc1）**
- Approve/Reject 抛错（如批次已被丢弃）时弹出后端错误信息，按钮不再表现为「点不动」

### 测试
- 前端 tsc --noEmit / oxlint / vite build 全部通过
- Windows exe 实测（含 UI 自动化逐元素验证 + 会话存档落盘核验）：待批准时返回主页后主页无残留；重进会话显示「继续任务」且无死审批条；点击继续任务恢复请求，完成后滞留卡从界面与会话存档中彻底清除；追问应答后卡片消失；任务完成后无滞留卡片

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持在自由文本追问框中按 Enter 提交，Shift+Enter 和输入法编辑状态除外；空白内容无法继续。
  * 任务恢复入口现在可识别未完成的交互式工具任务。

* **问题修复**
  * 自动清理完成、取消或出错后残留的工具卡片和追问卡片。
  * 被拒绝或已处理的交互卡片不再重复显示。
  * 工具批准或拒绝失败时显示明确的错误提示。
  * 优化面板重新加载、取消任务及状态保存，避免出现失效操作栏或过期卡片。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->